### PR TITLE
feat: Qualification for pay sheets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,11 +185,11 @@ class MyPeopleDocConnector extends CookieKonnector {
           vendorRef: doc.id,
           metadata: {
             contentAuthor: 'mypeopledoc.com',
-            issueDate: doc.date,
+            issueDate: new Date(doc.created_at),
             datetime: new Date(),
             datetimeLabel: `issueDate`,
             carbonCopy: true,
-            qualification: Qualification.getByLabel('pay_sheet')
+            qualification: this.evalQualifications(doc)
           },
           requestOptions: {
             headers: {
@@ -205,6 +205,16 @@ class MyPeopleDocConnector extends CookieKonnector {
     }
 
     return documents
+  }
+
+  evalQualifications(doc) {
+    const normalizedDocTitle = doc.title.toLowerCase()
+    if (normalizedDocTitle.match(/bulletins?|salaire|paie/g)) {
+      return Qualification.getByLabel('pay_sheet')
+    }
+    // As we can't tell for sure yet what type will be the others docs
+    // we return undefined
+    return undefined
   }
 }
 


### PR DESCRIPTION
As every compagny seems to be able to add different filename/title/tags for the files they upload on myPeopleDoc, we got to find a large enough range of naming possibilities to qualify the file we downloading on the user's Cozy. 
Beside, it appears that in myPeopleDoc you can find a lot more cases where the files aren't just pay sheets (as mentionned by a contributor earlier) but we didn't dispose of enough accounts to check on for similarities regarding the naming of those other files. Until we can qualify them better, we will use "undefined" as we cannot tell the right type yet.